### PR TITLE
Added monitor speed and library depedencies

### DIFF
--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -12,3 +12,10 @@
 platform = espressif32
 board = nodemcu-32s
 framework = arduino
+monitor_speed = 115200
+lib_deps =
+    Adafruit GFX Library
+    ArduinoJson-esphomelib
+    ESP Async WebServer
+    GxEPD
+    Pushbutton


### PR DESCRIPTION
This will ensure that PlatformIO will automatically install the correct libraries and use the right speed for it's monitor function.